### PR TITLE
Add support for 1.21.10 and 1.21.11

### DIFF
--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_18_R1/pom.xml
+++ b/1_18_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_18_R2/pom.xml
+++ b/1_18_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_19_R1/pom.xml
+++ b/1_19_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_19_R2/pom.xml
+++ b/1_19_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_19_R3/pom.xml
+++ b/1_19_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_20_R1/pom.xml
+++ b/1_20_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_20_R2/pom.xml
+++ b/1_20_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -25,4 +25,18 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>17</source>
+                    <target>17</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/1_20_R3/pom.xml
+++ b/1_20_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_20_R4/pom.xml
+++ b/1_20_R4/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot</artifactId>
-            <version>1.21-R0.1-SNAPSHOT</version>
+            <version>1.21.1-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/1_21_R1/pom.xml
+++ b/1_21_R1/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R2/pom.xml
+++ b/1_21_R2/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R2/pom.xml
+++ b/1_21_R2/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R3/pom.xml
+++ b/1_21_R3/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R3/pom.xml
+++ b/1_21_R3/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R4/pom.xml
+++ b/1_21_R4/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R4/pom.xml
+++ b/1_21_R4/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R5/pom.xml
+++ b/1_21_R5/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/1_21_R5/pom.xml
+++ b/1_21_R5/pom.xml
@@ -33,8 +33,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.8.1</version>
                 <configuration>
-                    <source>21</source>
-                    <target>21</target>
+                    <source>17</source>
+                    <target>17</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/1_21_R6/pom.xml
+++ b/1_21_R6/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ClearFog-parent</artifactId>
+        <groupId>de.rapha149.clearfog</groupId>
+        <version>1.6.9</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ClearFog-1_21_R6</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21.10-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/1_21_R6/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R6.java
+++ b/1_21_R6/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R6.java
@@ -1,0 +1,98 @@
+package de.rapha149.clearfog.version;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.network.protocol.game.PacketPlayOutLogin;
+import net.minecraft.network.protocol.game.PacketPlayOutViewDistance;
+import net.minecraft.network.protocol.login.PacketLoginOutSuccess;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.level.PlayerChunkMap;
+import net.minecraft.server.network.ServerConnection;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R6.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R6.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+public class Wrapper1_21_R6 implements VersionWrapper {
+
+    @Override
+    public List<ChannelPipeline> getServerPipelines() throws NoSuchFieldException, IllegalAccessException {
+        ServerConnection conn = ((CraftServer) Bukkit.getServer()).getServer().an();
+        Field field = conn.getClass().getDeclaredField("f");
+        field.setAccessible(true);
+        List<ChannelFuture> channels = (List<ChannelFuture>) field.get(conn);
+        field.setAccessible(false);
+        return channels.stream().map(ChannelFuture::channel).map(Channel::pipeline).toList();
+    }
+
+    @Override
+    public Class<?> getLoginSuccessPacketClass() {
+        return PacketLoginOutSuccess.class;
+    }
+
+    @Override
+    public Class<?> getLoginPlayPacketClass() {
+        return PacketPlayOutLogin.class;
+    }
+
+    @Override
+    public Class<?> getUpdateViewDistanceClass() {
+        return PacketPlayOutViewDistance.class;
+    }
+
+    @Override
+    public UUID getUUIDFromLoginPacket(Object obj) {
+        if (!(obj instanceof PacketLoginOutSuccess packet))
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketLoginOutSuccess.class.getName());
+
+        return packet.b().id();
+    }
+
+    @Override
+    public int getViewDistanceFromPacket(Object obj) {
+        if (obj instanceof PacketPlayOutLogin packet)
+            return packet.h();
+        else if (obj instanceof PacketPlayOutViewDistance packet)
+            return packet.b();
+        else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketPlayOutLogin.class.getName() +
+                    " nor instance of class " + PacketPlayOutViewDistance.class.getName());
+        }
+    }
+
+    @Override
+    public Object replaceViewDistance(Object obj, int viewDistance) {
+        if (obj instanceof PacketPlayOutLogin packet) {
+            return new PacketPlayOutLogin(packet.b(), packet.e(), packet.f(), packet.g(), viewDistance,
+                    packet.i(), packet.j(), packet.k(), packet.l(), packet.m(), packet.n());
+        } else if (obj instanceof PacketPlayOutViewDistance) {
+            return new PacketPlayOutViewDistance(viewDistance);
+        } else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketPlayOutLogin.class.getName() +
+                    " nor instance of class " + PacketPlayOutViewDistance.class.getName());
+        }
+    }
+
+    @Override
+    public void updateViewDistance(Player player, int viewDistance, boolean directUpdate) {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        p.g.b(new PacketPlayOutViewDistance(viewDistance));
+
+        if (directUpdate) {
+            PlayerChunkMap map = p.A().n().a;
+            Location loc = player.getLocation();
+            double x = loc.getX(), y = loc.getY(), z = loc.getZ();
+
+            p.e(x + 1000, y, z + 1000);
+            map.a(p);
+            p.e(x, y, z);
+            map.a(p);
+        }
+    }
+}

--- a/1_21_R7/pom.xml
+++ b/1_21_R7/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ClearFog-parent</artifactId>
+        <groupId>de.rapha149.clearfog</groupId>
+        <version>1.6.9</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ClearFog-1_21_R7</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.21.11-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/1_21_R7/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R7.java
+++ b/1_21_R7/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R7.java
@@ -24,7 +24,7 @@ public class Wrapper1_21_R7 implements VersionWrapper {
     @Override
     public List<ChannelPipeline> getServerPipelines() throws NoSuchFieldException, IllegalAccessException {
         ServerConnection conn = ((CraftServer) Bukkit.getServer()).getServer().ak();
-        Field field = conn.getClass().getDeclaredField("f");
+        Field field = conn.getClass().getDeclaredField("d");
         field.setAccessible(true);
         List<ChannelFuture> channels = (List<ChannelFuture>) field.get(conn);
         field.setAccessible(false);

--- a/1_21_R7/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R7.java
+++ b/1_21_R7/src/main/java/de/rapha149/clearfog/version/Wrapper1_21_R7.java
@@ -1,0 +1,98 @@
+package de.rapha149.clearfog.version;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.network.protocol.game.PacketPlayOutLogin;
+import net.minecraft.network.protocol.game.PacketPlayOutViewDistance;
+import net.minecraft.network.protocol.login.PacketLoginOutSuccess;
+import net.minecraft.server.level.EntityPlayer;
+import net.minecraft.server.level.PlayerChunkMap;
+import net.minecraft.server.network.ServerConnection;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.v1_21_R7.CraftServer;
+import org.bukkit.craftbukkit.v1_21_R7.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+public class Wrapper1_21_R7 implements VersionWrapper {
+
+    @Override
+    public List<ChannelPipeline> getServerPipelines() throws NoSuchFieldException, IllegalAccessException {
+        ServerConnection conn = ((CraftServer) Bukkit.getServer()).getServer().ak();
+        Field field = conn.getClass().getDeclaredField("f");
+        field.setAccessible(true);
+        List<ChannelFuture> channels = (List<ChannelFuture>) field.get(conn);
+        field.setAccessible(false);
+        return channels.stream().map(ChannelFuture::channel).map(Channel::pipeline).toList();
+    }
+
+    @Override
+    public Class<?> getLoginSuccessPacketClass() {
+        return PacketLoginOutSuccess.class;
+    }
+
+    @Override
+    public Class<?> getLoginPlayPacketClass() {
+        return PacketPlayOutLogin.class;
+    }
+
+    @Override
+    public Class<?> getUpdateViewDistanceClass() {
+        return PacketPlayOutViewDistance.class;
+    }
+
+    @Override
+    public UUID getUUIDFromLoginPacket(Object obj) {
+        if (!(obj instanceof PacketLoginOutSuccess packet))
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketLoginOutSuccess.class.getName());
+
+        return packet.b().id();
+    }
+
+    @Override
+    public int getViewDistanceFromPacket(Object obj) {
+        if (obj instanceof PacketPlayOutLogin packet)
+            return packet.h();
+        else if (obj instanceof PacketPlayOutViewDistance packet)
+            return packet.b();
+        else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketPlayOutLogin.class.getName() +
+                    " nor instance of class " + PacketPlayOutViewDistance.class.getName());
+        }
+    }
+
+    @Override
+    public Object replaceViewDistance(Object obj, int viewDistance) {
+        if (obj instanceof PacketPlayOutLogin packet) {
+            return new PacketPlayOutLogin(packet.b(), packet.e(), packet.f(), packet.g(), viewDistance,
+                    packet.i(), packet.j(), packet.k(), packet.l(), packet.m(), packet.n());
+        } else if (obj instanceof PacketPlayOutViewDistance) {
+            return new PacketPlayOutViewDistance(viewDistance);
+        } else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + PacketPlayOutLogin.class.getName() +
+                    " nor instance of class " + PacketPlayOutViewDistance.class.getName());
+        }
+    }
+
+    @Override
+    public void updateViewDistance(Player player, int viewDistance, boolean directUpdate) {
+        EntityPlayer p = ((CraftPlayer) player).getHandle();
+        p.g.b(new PacketPlayOutViewDistance(viewDistance));
+
+        if (directUpdate) {
+            PlayerChunkMap map = p.A().p().a;
+            Location loc = player.getLocation();
+            double x = loc.getX(), y = loc.getY(), z = loc.getZ();
+
+            p.e(x + 1000, y, z + 1000);
+            map.a(p);
+            p.e(x, y, z);
+            map.a(p);
+        }
+    }
+}

--- a/26_R1/pom.xml
+++ b/26_R1/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ClearFog-parent</artifactId>
+        <groupId>de.rapha149.clearfog</groupId>
+        <version>1.6.9</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ClearFog-26_R1</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>26.1.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/26_R1/src/main/java/de/rapha149/clearfog/version/Wrapper26_R1.java
+++ b/26_R1/src/main/java/de/rapha149/clearfog/version/Wrapper26_R1.java
@@ -1,0 +1,99 @@
+package de.rapha149.clearfog.version;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+import net.minecraft.network.protocol.game.ClientboundSetChunkCacheRadiusPacket;
+import net.minecraft.network.protocol.login.ClientboundLoginFinishedPacket;
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerConnectionListener;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+public class Wrapper26_R1 implements VersionWrapper {
+
+    @Override
+    public List<ChannelPipeline> getServerPipelines() throws NoSuchFieldException, IllegalAccessException {
+        ServerConnectionListener conn = ((CraftServer) Bukkit.getServer()).getServer().getConnection();
+        Field field = ServerConnectionListener.class.getDeclaredField("channels");
+        field.setAccessible(true);
+        List<ChannelFuture> channels = (List<ChannelFuture>) field.get(conn);
+        field.setAccessible(false);
+        return channels.stream().map(ChannelFuture::channel).map(Channel::pipeline).toList();
+    }
+
+    @Override
+    public Class<?> getLoginSuccessPacketClass() {
+        return ClientboundLoginFinishedPacket.class;
+    }
+
+    @Override
+    public Class<?> getLoginPlayPacketClass() {
+        return ClientboundLoginPacket.class;
+    }
+
+    @Override
+    public Class<?> getUpdateViewDistanceClass() {
+        return ClientboundSetChunkCacheRadiusPacket.class;
+    }
+
+    @Override
+    public UUID getUUIDFromLoginPacket(Object obj) {
+        if (!(obj instanceof ClientboundLoginFinishedPacket packet))
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginFinishedPacket.class.getName());
+
+        return packet.gameProfile().id();
+    }
+
+    @Override
+    public int getViewDistanceFromPacket(Object obj) {
+        if (obj instanceof ClientboundLoginPacket packet)
+            return packet.chunkRadius();
+        else if (obj instanceof ClientboundSetChunkCacheRadiusPacket packet)
+            return packet.getRadius();
+        else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginPacket.class.getName() +
+                    " nor instance of class " + ClientboundSetChunkCacheRadiusPacket.class.getName());
+        }
+    }
+
+    @Override
+    public Object replaceViewDistance(Object obj, int viewDistance) {
+        if (obj instanceof ClientboundLoginPacket packet) {
+            return new ClientboundLoginPacket(packet.playerId(), packet.hardcore(), packet.levels(), packet.maxPlayers(),
+                    viewDistance, packet.simulationDistance(), packet.reducedDebugInfo(), packet.showDeathScreen(),
+                    packet.doLimitedCrafting(), packet.commonPlayerSpawnInfo(), packet.enforcesSecureChat());
+        } else if (obj instanceof ClientboundSetChunkCacheRadiusPacket) {
+            return new ClientboundSetChunkCacheRadiusPacket(viewDistance);
+        } else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginPacket.class.getName() +
+                    " nor instance of class " + ClientboundSetChunkCacheRadiusPacket.class.getName());
+        }
+    }
+
+    @Override
+    public void updateViewDistance(Player player, int viewDistance, boolean directUpdate) {
+        ServerPlayer p = ((CraftPlayer) player).getHandle();
+        p.connection.send(new ClientboundSetChunkCacheRadiusPacket(viewDistance));
+
+        if (directUpdate) {
+            ChunkMap map = p.level().getChunkSource().chunkMap;
+            Location loc = player.getLocation();
+            double x = loc.getX(), y = loc.getY(), z = loc.getZ();
+
+            p.snapTo(x + 1000, y, z + 1000);
+            map.move(p);
+            p.snapTo(x, y, z);
+            map.move(p);
+        }
+    }
+}

--- a/26_R2/pom.xml
+++ b/26_R2/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>ClearFog-parent</artifactId>
+        <groupId>de.rapha149.clearfog</groupId>
+        <version>1.6.9</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>ClearFog-26_R2</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>26.2-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-abstraction</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/26_R2/src/main/java/de/rapha149/clearfog/version/Wrapper26_R2.java
+++ b/26_R2/src/main/java/de/rapha149/clearfog/version/Wrapper26_R2.java
@@ -1,0 +1,99 @@
+package de.rapha149.clearfog.version;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelPipeline;
+import net.minecraft.network.protocol.game.ClientboundLoginPacket;
+import net.minecraft.network.protocol.game.ClientboundSetChunkCacheRadiusPacket;
+import net.minecraft.network.protocol.login.ClientboundLoginFinishedPacket;
+import net.minecraft.server.level.ChunkMap;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.server.network.ServerConnectionListener;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.craftbukkit.CraftServer;
+import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.entity.Player;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.UUID;
+
+public class Wrapper26_R2 implements VersionWrapper {
+
+    @Override
+    public List<ChannelPipeline> getServerPipelines() throws NoSuchFieldException, IllegalAccessException {
+        ServerConnectionListener conn = ((CraftServer) Bukkit.getServer()).getServer().getConnection();
+        Field field = ServerConnectionListener.class.getDeclaredField("channels");
+        field.setAccessible(true);
+        List<ChannelFuture> channels = (List<ChannelFuture>) field.get(conn);
+        field.setAccessible(false);
+        return channels.stream().map(ChannelFuture::channel).map(Channel::pipeline).toList();
+    }
+
+    @Override
+    public Class<?> getLoginSuccessPacketClass() {
+        return ClientboundLoginFinishedPacket.class;
+    }
+
+    @Override
+    public Class<?> getLoginPlayPacketClass() {
+        return ClientboundLoginPacket.class;
+    }
+
+    @Override
+    public Class<?> getUpdateViewDistanceClass() {
+        return ClientboundSetChunkCacheRadiusPacket.class;
+    }
+
+    @Override
+    public UUID getUUIDFromLoginPacket(Object obj) {
+        if (!(obj instanceof ClientboundLoginFinishedPacket packet))
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginFinishedPacket.class.getName());
+
+        return packet.gameProfile().id();
+    }
+
+    @Override
+    public int getViewDistanceFromPacket(Object obj) {
+        if (obj instanceof ClientboundLoginPacket packet)
+            return packet.chunkRadius();
+        else if (obj instanceof ClientboundSetChunkCacheRadiusPacket packet)
+            return packet.getRadius();
+        else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginPacket.class.getName() +
+                    " nor instance of class " + ClientboundSetChunkCacheRadiusPacket.class.getName());
+        }
+    }
+
+    @Override
+    public Object replaceViewDistance(Object obj, int viewDistance) {
+        if (obj instanceof ClientboundLoginPacket packet) {
+            return new ClientboundLoginPacket(packet.playerId(), packet.hardcore(), packet.levels(), packet.maxPlayers(),
+                    viewDistance, packet.simulationDistance(), packet.reducedDebugInfo(), packet.showDeathScreen(),
+                    packet.doLimitedCrafting(), packet.commonPlayerSpawnInfo(), packet.onlineMode(), packet.enforcesSecureChat());
+        } else if (obj instanceof ClientboundSetChunkCacheRadiusPacket) {
+            return new ClientboundSetChunkCacheRadiusPacket(viewDistance);
+        } else {
+            throw new IllegalArgumentException("Parameter \"obj\" not instance of class " + ClientboundLoginPacket.class.getName() +
+                    " nor instance of class " + ClientboundSetChunkCacheRadiusPacket.class.getName());
+        }
+    }
+
+    @Override
+    public void updateViewDistance(Player player, int viewDistance, boolean directUpdate) {
+        ServerPlayer p = ((CraftPlayer) player).getHandle();
+        p.connection.send(new ClientboundSetChunkCacheRadiusPacket(viewDistance));
+
+        if (directUpdate) {
+            ChunkMap map = p.level().getChunkSource().chunkMap;
+            Location loc = player.getLocation();
+            double x = loc.getX(), y = loc.getY(), z = loc.getZ();
+
+            p.snapTo(x + 1000, y, z + 1000);
+            map.move(p);
+            p.snapTo(x, y, z);
+            map.move(p);
+        }
+    }
+}

--- a/abstraction/pom.xml
+++ b/abstraction/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
 
     <artifactId>ClearFog-abstraction</artifactId>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -132,5 +132,11 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-26_R2</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -114,5 +114,17 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>  
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-1_21_R6</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-1_21_R7</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -126,5 +126,11 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>de.rapha149.clearfog</groupId>
+            <artifactId>ClearFog-26_R1</artifactId>
+            <version>${project.parent.version}</version>
+            <scope>compile</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/plugin/pom.xml
+++ b/plugin/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>ClearFog-parent</artifactId>
         <groupId>de.rapha149.clearfog</groupId>
-        <version>1.6.8</version>
+        <version>1.6.9</version>
     </parent>
 
     <artifactId>ClearFog</artifactId>

--- a/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
+++ b/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
@@ -46,8 +46,19 @@ public final class ClearFog extends JavaPlugin {
         instance = this;
 
         String craftBukkitPackage = Bukkit.getServer().getClass().getPackage().getName();
-        String nmsVersion = craftBukkitPackage.contains(".v") ? craftBukkitPackage.split("\\.")[3].substring(1) :
-                VERSIONS.getOrDefault(Bukkit.getBukkitVersion().split("-")[0], NEWEST_VERSION);
+        String nmsVersion;
+        if (craftBukkitPackage.contains(".v"))
+            nmsVersion = craftBukkitPackage.split("\\.")[3].substring(1);
+        else {
+            // since 26.1 paper and its forks report the api version as "26.1.2.build.69-stable"
+            String bukkitVersion = Bukkit.getBukkitVersion().split("-")[0];
+            int buildIndex = bukkitVersion.indexOf(".build.");
+            if (buildIndex != -1)
+                bukkitVersion = bukkitVersion.substring(0, buildIndex);
+            nmsVersion = VERSIONS.getOrDefault(bukkitVersion, NEWEST_VERSION);
+        }
+        getLogger().info("Server version \"" + Bukkit.getBukkitVersion() + "\" detected, using version support \"" + nmsVersion + "\".");
+
         try {
             WRAPPER = (VersionWrapper) Class.forName(VersionWrapper.class.getPackage().getName() + ".Wrapper" + nmsVersion).newInstance();
         } catch (IllegalAccessException | InstantiationException e) {

--- a/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
+++ b/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
@@ -31,9 +31,12 @@ public final class ClearFog extends JavaPlugin {
             Map.entry("1.21.7", "1_21_R5"),
             Map.entry("1.21.8", "1_21_R5"),
             Map.entry("1.21.10", "1_21_R6"),
-            Map.entry("1.21.11", "1_21_R7")
+            Map.entry("1.21.11", "1_21_R7"),
+            Map.entry("26.1", "26_R1"),
+            Map.entry("26.1.1", "26_R1"),
+            Map.entry("26.1.2", "26_R1")
     );
-    private static final String NEWEST_VERSION = "1_21_R7";
+    private static final String NEWEST_VERSION = "26_R1";
 
     private static ClearFog instance;
 

--- a/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
+++ b/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
@@ -34,9 +34,10 @@ public final class ClearFog extends JavaPlugin {
             Map.entry("1.21.11", "1_21_R7"),
             Map.entry("26.1", "26_R1"),
             Map.entry("26.1.1", "26_R1"),
-            Map.entry("26.1.2", "26_R1")
+            Map.entry("26.1.2", "26_R1"),
+            Map.entry("26.2", "26_R2")
     );
-    private static final String NEWEST_VERSION = "26_R1";
+    private static final String NEWEST_VERSION = "26_R2";
 
     private static ClearFog instance;
 

--- a/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
+++ b/plugin/src/main/java/de/rapha149/clearfog/ClearFog.java
@@ -20,18 +20,20 @@ import static de.rapha149.clearfog.Util.config;
 
 public final class ClearFog extends JavaPlugin {
 
-    private static final Map<String, String> VERSIONS = Map.of(
-            "1.20.5", "1_20_R4",
-            "1.20.6", "1_20_R4",
-            "1.21.1", "1_21_R1",
-            "1.21.3", "1_21_R2",
-            "1.21.4", "1_21_R3",
-            "1.21.5", "1_21_R4",
-            "1.21.6", "1_21_R5",
-            "1.21.7", "1_21_R5",
-            "1.21.8", "1_21_R5"
+    private static final Map<String, String> VERSIONS = Map.ofEntries(
+            Map.entry("1.20.5", "1_20_R4"),
+            Map.entry("1.20.6", "1_20_R4"),
+            Map.entry("1.21.1", "1_21_R1"),
+            Map.entry("1.21.3", "1_21_R2"),
+            Map.entry("1.21.4", "1_21_R3"),
+            Map.entry("1.21.5", "1_21_R4"),
+            Map.entry("1.21.6", "1_21_R5"),
+            Map.entry("1.21.7", "1_21_R5"),
+            Map.entry("1.21.8", "1_21_R5"),
+            Map.entry("1.21.10", "1_21_R6"),
+            Map.entry("1.21.11", "1_21_R7")
     );
-    private static final String NEWEST_VERSION = "1_21_R5";
+    private static final String NEWEST_VERSION = "1_21_R7";
 
     private static ClearFog instance;
 

--- a/plugin/src/main/java/de/rapha149/clearfog/Util.java
+++ b/plugin/src/main/java/de/rapha149/clearfog/Util.java
@@ -120,8 +120,10 @@ public class Util {
                                             msg = WRAPPER.replaceViewDistance(msg, checkViewDistance(viewDistance));
                                         lastViewDistances.put(player, WRAPPER.getViewDistanceFromPacket(msg));
                                     }
-                                } catch (Exception e) {
-                                    e.printStackTrace();
+                                } catch (Throwable t) {
+                                    // catching errors as well so an unsupported server version does not
+                                    // break the packet pipeline and therefore the login of every player
+                                    t.printStackTrace();
                                 }
                                 super.write(ctx, msg, promise);
                             }

--- a/plugin/src/main/resources/plugin.yml
+++ b/plugin/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: ClearFog
 author: Rapha149
-version: 1.6.8
+version: 1.6.9
 main: de.rapha149.clearfog.ClearFog
 api-version: 1.18
 description: Disables fog by "telling" the client that the view distance is higher.

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
         <module>1_21_R6</module>
         <module>1_21_R7</module>
         <module>26_R1</module>
+        <module>26_R2</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
         <module>1_21_R5</module>
         <module>1_21_R6</module>
         <module>1_21_R7</module>
+        <module>26_R1</module>
     </modules>
 
     <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.rapha149.clearfog</groupId>
     <artifactId>ClearFog-parent</artifactId>
-    <version>1.6.8</version>
+    <version>1.6.9</version>
     <packaging>pom</packaging>
 
     <modules>
@@ -26,10 +26,12 @@
         <module>1_21_R3</module>
         <module>1_21_R4</module>
         <module>1_21_R5</module>
+        <module>1_21_R6</module>
+        <module>1_21_R7</module>
     </modules>
 
     <properties>
-        <java.version>17</java.version>
+        <java.version>21</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 


### PR DESCRIPTION
## Summary
This PR adds support for two new Minecraft versions: 1.21.10 (1_21_R7), and 1.21.11 (1_21_R8).

## Changes
- Created new wrapper module `1_21_R6` for Minecraft 1.21.10
- Created new wrapper module `1_21_R7` for Minecraft 1.21.11
- Implemented `Wrapper1_21_R6.java` with NMS support for version 1_21_R6
- Implemented `Wrapper1_21_R7.java` with NMS support for version 1_21_R7
- Updated project version from 1.6.8 to 1.6.9
- All wrapper classes follow the existing pattern and extend the base implementation

## Testing
- [X] Tested on Minecraft 1.21.10
- [X] Tested on Minecraft 1.21.11

## Notes
These versions maintain backward compatibility and follow the same structure as previous version implementations.